### PR TITLE
Changed sessionlist > session to sessionlistitem

### DIFF
--- a/src/components/sessions/Session.js
+++ b/src/components/sessions/Session.js
@@ -1,34 +1,27 @@
 import React from 'react';
-import WorkoutList from '../workouts/WorkoutList';
-import {Link, BrowserRouter, Route} from 'react-router-dom';
 
 export default class Session extends React.Component {
 
+    constructor(props){
+        super(props);
+        this.state = {
+            session: null
+        }
+    }
+
+    // Hit get /session/:id endpoint to get sessionid, date, muscles_worked
+
+    // also hit workouts endpoint -> something like /session/{this.state.sessionid}/workouts
+    // https://stackoverflow.com/questions/49754270/multiple-fetch-requests-with-setstate-in-react
+
     render() {
         return(
-            // <BrowserRouter>
                 <div>
-                    <p>Session ID: {this.props.sessionData.id}</p>
-                    <p>Session Date: {this.props.sessionData.date}</p>
-                    <p>Muscles Worked: {this.props.sessionData.muscles_worked}</p>
-                    <Link to={{ 
-                        pathname: `/sessions/${this.props.sessionData.id}`}}>
-                        View Workouts
-                    </Link>
-                    <hr/>
-                    {/* <Route path={`/sessions/${this.props.sessionData.id}`} component={Home}/> */}
-                    <hr/>
+                {/* render date here once */}
+                {/* render workoutlist here */}
+                    <p>Hello world + {this.props.match.params.id}</p>
                 </div>
-            // </BrowserRouter>
         )
-
-        // function Home() {
-        //     return (
-        //         <div>
-        //             <h2>Home + {this.props.hello}</h2>
-        //         </div>
-        //     );
-        // }
     }   
       
 }

--- a/src/components/sessions/SessionsList.js
+++ b/src/components/sessions/SessionsList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
-import Session from './Session';
+import SessionsListItem from './SessionsListItem';
 
 export default class SessionsList extends React.Component {
 
@@ -34,7 +34,7 @@ export default class SessionsList extends React.Component {
 
                 {this.state.sessions.map(function (session) {
                     return (
-                        <Session key={session.id} sessionData={session}/>
+                        <SessionsListItem key={session.id} sessionData={session}/>
                     )
                 })}
             </div>

--- a/src/components/sessions/SessionsListItem.js
+++ b/src/components/sessions/SessionsListItem.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import {Link} from 'react-router-dom';
+
+
+export default class SessionListItem extends React.Component {
+
+    render() {
+        return (
+            <div>
+                <p>Session ID: {this.props.sessionData.id}</p>
+                <p>Session Date: {this.props.sessionData.date}</p>
+                <p>Muscles Worked: {this.props.sessionData.muscles_worked}</p>
+                <Link to={{ 
+                    pathname: `/sessions/${this.props.sessionData.id}`}}>
+                    View Workouts
+                </Link>
+            </div>
+        )
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { Route, Switch, BrowserRouter as Router } from 'react-router-dom';
 
 import Home from './components/Home';
 import SessionsList from './components/sessions/SessionsList';
-import WorkoutList from './components/workouts/WorkoutList';
+import Session from './components/sessions/Session';
 import NewSession from './components/sessions/NewSession';
 
 const routing = (
@@ -13,7 +13,7 @@ const routing = (
             <Switch>
                 <Route exact path="/" component={Home}/>
                 <Route exact path="/sessions" component={SessionsList}/>
-                <Route path="/sessions/:id" component={WorkoutList}/>
+                <Route path="/sessions/:id" component={Session}/>
                 <Route path="/new-session" component={NewSession}/>
             </Switch>
         </div>


### PR DESCRIPTION
Fixes #25

SessionList renders list of SessionListItems ->which are only responsible for displaying id, date, and muscles_worked, along with link to respective session. SessionList calls api endpoint /sessions to get all session data. Maps to list of SessionListItems.

When I hit host:3000/sessions/1 -> this will render Session -> which is responsible for making fetch requests for /session/:id and /session/:id/workouts. Session will render WorkoutList which will map to a list of WorkoutListItem.